### PR TITLE
bump: 1.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.9
+version: 1.1.0
 
 environment:
   sdk: ^3.10.3


### PR DESCRIPTION
## Summary
- Bump version from 1.0.9 to 1.1.0

## Test plan
- [ ] CI builds APK successfully on merge to main
- [ ] `v1.1.0` tag is created and changelog is generated