### PR TITLE
fix: auth token race condition after login

### DIFF
--- a/lib/providers/auth/auth_provider.dart
+++ b/lib/providers/auth/auth_provider.dart
@@ -61,6 +61,7 @@ class AuthNotifier extends Notifier<AuthState> {
   }
 
   Future<void> setToken(String token) async {
+    state = AuthState(status: AuthStatus.authenticated, token: token);
     await _storage.write(key: _tokenKey, value: token);
     try {
       final user = await _authService.me();
@@ -70,7 +71,7 @@ class AuthNotifier extends Notifier<AuthState> {
         user: user,
       );
     } catch (e) {
-      state = AuthState(status: AuthStatus.authenticated, token: token);
+      // Keep token even if user fetch fails
     }
   }
 


### PR DESCRIPTION
## Summary
- `setToken()` was calling `/me` before updating Riverpod state, so `AuthInterceptor.getToken()` returned null
- The `/me` request was sent without an Authorization header, returning 401
- This also triggered a spurious `/refresh` call (also without token) that failed with 401
- Fixed by setting state with the token **before** the `/me` call, matching the existing `loadFromStorage()` pattern

## Test plan
- [ ] Login with valid credentials — verify no 401 errors in logs for `/me` or `/refresh`
- [ ] Verify user profile loads immediately after login
- [ ] Verify marquer backend requests continue working with token

🤖 Generated with [Claude Code](https://claude.com/claude-code)